### PR TITLE
[TASK] Add GitHub Dependabot and community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug in AI Foundation (`ns_t3af`)!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Open AI Foundation → Providers
+        2. Configure provider '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: input
+    id: t3af-version
+    attributes:
+      label: ns_t3af Version
+      placeholder: "1.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: typo3-version
+    attributes:
+      label: TYPO3 Version
+      placeholder: "13.4.0"
+    validations:
+      required: true
+
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP Version
+      placeholder: "8.2.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Providers / adapters
+        - MCP server / tools
+        - AI Context (brand profiles)
+        - AI Access & Roles
+        - Credits / billing
+        - Dashboard / backend module
+        - AI Logs
+        - Child extension integration
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: LLM Provider (if relevant)
+      options:
+        - OpenAI
+        - Anthropic Claude
+        - Google Gemini
+        - Azure OpenAI
+        - Mistral
+        - Ollama
+        - OpenRouter
+        - OpenAI-compatible / Custom
+        - T3Planet Credits
+        - N/A
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support
+    url: https://t3planet.de/en/support
+    about: Product and license support from T3Planet
+  - name: Security Vulnerability
+    url: https://github.com/nitsan-technologies/ns_t3af/security/policy
+    about: Report security issues privately (see SECURITY.md / security@t3planet.de)
+  - name: Documentation
+    url: https://docs.t3planet.de/en/latest/
+    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature for AI Foundation (`ns_t3af`)!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: A clear description of the feature you'd like
+      placeholder: Describe the feature...
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe the problem this would solve
+      placeholder: I want to be able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions you've considered
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Providers / adapters
+        - Public API (AiServiceInterface)
+        - MCP server / tools / OAuth
+        - AI Context (brand profiles)
+        - AI Access & Roles
+        - Credits / billing
+        - Governance / telemetry
+        - Dashboard / backend module
+        - Child extension integration
+        - Documentation
+        - Other
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Description
+
+<!-- Describe your changes in detail -->
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses: Fixes #123 -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Checklist
+
+- [ ] My code follows the project's coding standards
+- [ ] I have run `composer test` (and `composer test:functional` when relevant)
+- [ ] I have run `composer stan` and `composer cs:check`
+- [ ] I have added tests that prove my fix/feature works
+- [ ] I have updated the documentation / `context/` when behaviour changes
+- [ ] My changes generate no new warnings
+- [ ] Commits are signed off (`git commit -s`) per CONTRIBUTING.md (DCO)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot for nitsan/ns-t3af (AI Foundation)
+#
+# Ecosystems: composer (extension composer.json) and github-actions.
+# Do not add npm unless a package.json exists at the declared directory —
+# missing manifests make Dependabot fail with dependency_file_not_found.
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
+    groups:
+      composer:
+        patterns: ['*']
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+# Label configuration for PR Labeler
+# https://github.com/actions/labeler
+# Requires a workflow that runs actions/labeler.
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['Documentation/**/*', '**/*.md', 'context/**/*']
+tests:
+  - changed-files:
+      - any-glob-to-any-file: ['Tests/**/*', 'Build/phpunit/**/*']
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**/*', 'Build/**/*', '.gitlab-ci.yml']
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ['composer.json', 'composer.lock']
+configuration:
+  - changed-files:
+      - any-glob-to-any-file: ['Configuration/**/*', 'ext_*.php', 'ext_*.txt', 'ext_*.sql', 'composer.json']


### PR DESCRIPTION
## Description

Bootstrap `.github/` for the public GitHub repo with Dependabot and community contribution templates.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

Also: repo tooling / CI-adjacent config (Dependabot).

## What changed

- `.github/dependabot.yml` — weekly Monday updates for **Composer** and **GitHub Actions** (grouped PRs, 7-day cooldown; no npm)
- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist (`composer test` / `stan` / `cs:check`, DCO)
- `.github/ISSUE_TEMPLATE/` — bug + feature forms + contact links (support, security, docs)
- `.github/labeler.yml` — path→label rules (ready for a future `actions/labeler` workflow)